### PR TITLE
Add info about aws authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Using [`eksctl`](https://github.com/weaveworks/eksctl) to deploy an EKS cluster.
 
+Install `aws-iam-authenticator`:
+
+```
+go get -u -v github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator
+
+```
+
+and `eksctl`:
+
+```
+brew install eksctl
+```
+
 Deploy to `us-east-1`:
 
 ```


### PR DESCRIPTION
AWS authenticator is required in order to use `kubectl` with EKS